### PR TITLE
Configurable Idle periods

### DIFF
--- a/stressberry/cli.py
+++ b/stressberry/cli.py
@@ -50,8 +50,15 @@ def _get_parser_run():
         "-d",
         "--duration",
         type=int,
-        default=600,
-        help="test duration in seconds (default: 600)",
+        default=300,
+        help="stress test duration in seconds (default: 300)",
+    )
+    parser.add_argument(
+        "-i",
+        "--idle",
+        type=int,
+        default=150,
+        help="idle time in seconds at start and end of stress test (default: 150)",
     )
     parser.add_argument(
         "-c",
@@ -69,11 +76,14 @@ def run(argv=None):
     args = parser.parse_args(argv)
 
     # Cool down first
-    print("Cooldown...")
+    print("Awaiting stable baseline temperature...")
     cooldown(filename=args.temperature_file)
 
     # Start the stress test in another thread
-    t = threading.Thread(target=lambda: test(args.duration, args.cores), args=())
+    t = threading.Thread(
+        target=lambda: test(args.duration, args.idle, args.cores),
+        args=()
+    )
     t.start()
 
     times = []

--- a/stressberry/main.py
+++ b/stressberry/main.py
@@ -43,12 +43,9 @@ def cpu_core_count():
     return count
 
 
-def test(duration, cores):
+def test(stress_duration, idle_duration, cores):
     """Run stress test with 25% of test duration for idle before and after the stres
     """
-    stress_duration = 0.5 * duration
-    idle_duration = 0.25 * duration
-
     if cores is None:
         cores = cpu_core_count()
 


### PR DESCRIPTION
Make duration, the duration of the stress test element. Rather than the stress duration being 50% of the overall duration.
Make idle time at start and end of test configurable via command line, rather than being 25% of the duration each.

These changes are helpful when running long stress tests, where 25% idle team at each end of the test is excessive.

Defaults used give the same timings and overall test duration as before.